### PR TITLE
fix: prevent nil pointer error on FreeSubscribe

### DIFF
--- a/filefanoutqueue.go
+++ b/filefanoutqueue.go
@@ -333,10 +333,10 @@ func (q *FileFanoutQueue) doSubscribe(index int64, data []byte, err error) {
 }
 
 func (q *FileFanoutQueue) doLoopSubscribe(fanoutID int64, subscriber func(int64, []byte, error)) {
-	if subscriber == nil {
-		return
-	}
 	for {
+		if subscriber == nil {
+			return
+		}
 		index, bb, err := q.Dequeue(fanoutID)
 		if bb == nil || len(bb) == 0 {
 			break // queue is empty

--- a/filequeue.go
+++ b/filequeue.go
@@ -794,10 +794,10 @@ func (q *FileQueue) changeSubscribeStatusForce(s bool) {
 
 func (q *FileQueue) doLoopSubscribe() {
 	for {
-		if q.subscriber == nil {
-			return
-		}
 		for {
+			if q.subscriber == nil {
+				return
+			}
 			index, bb, err := q.Dequeue()
 			if bb == nil {
 				break // queue is empty


### PR DESCRIPTION
It is quite easy to get this panic in case somehow FreeSubscribe function is called, while doLoopSubscribe is still in the middle of the innermost loop:

> panic: runtime error: invalid memory address or nil pointer dereference
> [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x901bb4]
> 
> goroutine 49 [running]:
> github.com/jhunters/bigqueue.(*FileQueue).doLoopSubscribe(0xc0000b6370)
> 	/Users/nickgolikov/go/pkg/mod/github.com/jhunters/bigqueue@v1.2.2/filequeue.go:805 +0x54
> created by github.com/jhunters/bigqueue.(*FileQueue).Subscribe
> 	/Users/nickgolikov/go/pkg/mod/github.com/jhunters/bigqueue@v1.2.2/filequeue.go:775 +0x70

Which can happen in case the processing function, added in Subscribe, has any blocking logic with channels, for example, and the FreeSubscribe is called in some other routine.
Or if the FreeSubscribe is called in the subscribed function itself (I added the test purely for demonstration purposes, prior to proposed changes that test would trigger a panic).
