### PR TITLE
Fix permissions on dirs creation

### DIFF
--- a/filequeue.go
+++ b/filequeue.go
@@ -239,7 +239,7 @@ func (q *FileQueue) Open(dir string, queueName string, options *Options) error {
 
 	path := dir + "/" + queueName
 
-	err := os.MkdirAll(path, os.ModeDir)
+	err := os.MkdirAll(path, 0777)
 	if err != nil {
 		return err
 	}
@@ -672,25 +672,25 @@ func (q *FileQueue) getIndexItemArray(index int64) ([]byte, error) {
 
 func (q *FileQueue) initDirs() error {
 	indexFilePath := q.path + "/" + IndexFileName
-	err := os.MkdirAll(indexFilePath, os.ModeDir)
+	err := os.MkdirAll(indexFilePath, 0777)
 	if err != nil {
 		return err
 	}
 
 	dataFilePath := q.path + "/" + DataFileName
-	err = os.MkdirAll(dataFilePath, os.ModeDir)
+	err = os.MkdirAll(dataFilePath, 0777)
 	if err != nil {
 		return err
 	}
 
 	metaFilePath := q.path + "/" + MetaFileName
-	err = os.MkdirAll(metaFilePath, os.ModeDir)
+	err = os.MkdirAll(metaFilePath, 0777)
 	if err != nil {
 		return err
 	}
 
 	frontFilePath := q.path + "/" + FrontFileName
-	err = os.MkdirAll(frontFilePath, os.ModeDir)
+	err = os.MkdirAll(frontFilePath, 0777)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `os.ModeDir` option is not intended as a permissions preset, you should use the POSIX permissions set like `0777` for a dir, and `0666` for a file. Then the current `umask` of the current user will drop needed bits to the desired state.